### PR TITLE
Bump dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     },
     "main": "index.js",
     "dependencies": {
-        "keybase-bot": "^2.0.5",
+        "keybase-bot": "^3.6.1",
         "hubot": "3"
     },
     "peerDependencies": {


### PR DESCRIPTION
Fixes #2. Been running [this](https://github.com/mit-pdos/zero/blob/master/package.json#L14) since April and it seems to be stable.